### PR TITLE
Dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.1.1] - 2025-12-31
+
+### ✨ New Features
+
+- **Clear Queue Method** - Added `clearQueue()` method to cancel pending or ongoing autocomplete prediction requests.
+
+### 📚 Documentation
+
+- **Platform Interface Documentation** - Added missing documentation for `GooglePlacesAutocompletePlatform` class.
+
+---
+
 ## [2.1.0] - 2025-12-30
 
 ### 🚀 Enhancements

--- a/ios/google_places_autocomplete.podspec
+++ b/ios/google_places_autocomplete.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'google_places_autocomplete'
-  s.version          = '2.1.0'
+  s.version          = '2.1.1'
   s.summary          = 'Google Places Autocomplete for Flutter'
   s.description      = <<-DESC
 Seamlessly integrate Google Places API into your Flutter app with this package.

--- a/lib/src/google_places_autocomplete.dart
+++ b/lib/src/google_places_autocomplete.dart
@@ -175,6 +175,31 @@ class GooglePlacesAutocomplete {
     originLng = null;
   }
 
+  /// Clears and cancels any pending queued requests for fetching predictions.
+  ///
+  /// Use this when you want to immediately stop any in-flight autocomplete
+  /// requests, such as when the user navigates away, clears the search field,
+  /// or when you want to reset the search state.
+  ///
+  /// After calling this, you can still call [getPredictions] to start new
+  /// searches - the queue system will be automatically re-initialized.
+  ///
+  /// ## Example
+  /// ```dart
+  /// // Clear pending requests when user clears the search field
+  /// onClear: () {
+  ///   places.clearQueue();
+  ///   places.getPredictions(''); // This will return empty list
+  /// }
+  /// ```
+  void clearQueue() {
+    _subscription?.cancel();
+    _subscription = _subject.stream
+        .distinct()
+        .debounceTime(Duration(milliseconds: debounceTime))
+        .listen(_fetchPredictions);
+  }
+
   /// Initializes the native Places client.
   ///
   /// This must be called before using [getPredictions] or [getPlaceDetails].

--- a/lib/src/google_places_autocomplete_platform_interface.dart
+++ b/lib/src/google_places_autocomplete_platform_interface.dart
@@ -4,6 +4,11 @@ import 'google_places_autocomplete_method_channel.dart';
 import 'model/place_details.dart';
 import 'model/prediction.dart';
 
+/// The platform interface for Google Places Autocomplete.
+///
+/// This abstract class defines the API that platform-specific implementations
+/// must provide. It extends [PlatformInterface] to ensure proper platform
+/// interface verification.
 abstract class GooglePlacesAutocompletePlatform extends PlatformInterface {
   /// Constructs a GooglePlacesAutocompletePlatform.
   GooglePlacesAutocompletePlatform() : super(token: _token);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: google_places_autocomplete
 description: Seamlessly integrate Google Places API into your Flutter app with this package. Get location autocomplete, detailed place info, and flexible UI implementation.
 
-version: 2.1.0
+version: 2.1.1
 homepage: https://github.com/Cuboid-Inc/google_places_autocomplete
 repository: https://github.com/Cuboid-Inc/google_places_autocomplete
 


### PR DESCRIPTION
This pull request introduces a new method to clear pending autocomplete requests, updates documentation, and bumps the package version to `2.1.1`. The most important changes are:

**New Features**

* Added a `clearQueue()` method to the `GooglePlacesAutocomplete` class, allowing cancellation of pending or ongoing autocomplete prediction requests. This helps reset or stop in-flight searches, improving control over request handling.

**Documentation Improvements**

* Added missing documentation for the `GooglePlacesAutocompletePlatform` class, clarifying its role as the platform interface and its requirements for platform-specific implementations.

**Version Updates**

* Updated the version to `2.1.1` in `pubspec.yaml` and `ios/google_places_autocomplete.podspec` to reflect the new release. [[1]](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L4-R4) [[2]](diffhunk://#diff-aa95172db16ab6db0dce01986f24af23ad8e3e7eb62e7a5d4c4aef12db3b9146L7-R7)
* Updated the `CHANGELOG.md` to document the new feature and documentation improvements for version `2.1.1`.