### PR TITLE
Dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.1.2] - 2026-02-10
+
+### 🐛 Bug Fixes
+
+- **Eager Places SDK Initialization** - Fixed crash (`PlacesLightboxActivity` / `PlaceAutocompleteActivity`) caused by the Places SDK's built-in activities being launched (e.g., via map POI tap) before the Dart-side `initialize()` call. The plugin now eagerly initializes the Places SDK in `onAttachedToEngine` using the API key from `AndroidManifest.xml`.
+
+---
+
 ## [2.1.1] - 2025-12-31
 
 ### ✨ New Features

--- a/android/src/main/kotlin/com/cuboid/google_places_autocomplete/GooglePlacesAutocompletePlugin.kt
+++ b/android/src/main/kotlin/com/cuboid/google_places_autocomplete/GooglePlacesAutocompletePlugin.kt
@@ -38,9 +38,36 @@ class GooglePlacesAutocompletePlugin: FlutterPlugin, MethodCallHandler {
             channel = MethodChannel(flutterPluginBinding.binaryMessenger, CHANNEL_NAME)
             channel.setMethodCallHandler(this)
             context = flutterPluginBinding.applicationContext
+            
+            // Eagerly initialize Places SDK to prevent crashes from built-in
+            // activities (PlacesLightboxActivity, PlaceAutocompleteActivity)
+            // that are auto-registered via manifest merger and can be triggered
+            // by map POI interactions before the Dart-side initialize() call.
+            eagerlyInitializePlaces()
+            
             Log.d(TAG, "onAttachedToEngine: Plugin initialized successfully")
         } catch (e: Exception) {
             Log.e(TAG, "onAttachedToEngine: Failed to initialize plugin", e)
+        }
+    }
+    
+    /**
+     * Attempts to initialize the Places SDK using the API key from AndroidManifest.xml.
+     * This is a safety net — the Dart-side initialize() call will skip re-initialization
+     * since Places.isInitialized() will already return true.
+     */
+    private fun eagerlyInitializePlaces() {
+        if (Places.isInitialized()) return
+        try {
+            val apiKey = getApiKeyFromManifest()
+            if (apiKey != null) {
+                Places.initialize(context, apiKey)
+                Log.d(TAG, "eagerlyInitializePlaces: Places SDK pre-initialized from manifest")
+            } else {
+                Log.w(TAG, "eagerlyInitializePlaces: No API key in manifest, skipping eager init")
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "eagerlyInitializePlaces: Could not pre-initialize Places SDK", e)
         }
     }
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -81,7 +81,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.1"
+    version: "2.1.1"
   leak_tracker:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: google_places_autocomplete
 description: Seamlessly integrate Google Places API into your Flutter app with this package. Get location autocomplete, detailed place info, and flexible UI implementation.
 
-version: 2.1.1
+version: 2.1.2
 homepage: https://github.com/Cuboid-Inc/google_places_autocomplete
 repository: https://github.com/Cuboid-Inc/google_places_autocomplete
 


### PR DESCRIPTION
This pull request addresses a critical crash in the Android plugin by eagerly initializing the Places SDK as soon as the plugin is attached to the Flutter engine. This ensures that built-in Places SDK activities launched before the Dart-side `initialize()` call do not cause the app to crash. The version is also incremented to 2.1.2 and the change is documented in the changelog.

**Bug Fix: Eager Places SDK Initialization**

* Added `eagerlyInitializePlaces()` to `GooglePlacesAutocompletePlugin.kt`, ensuring the Places SDK is initialized with the API key from `AndroidManifest.xml` during `onAttachedToEngine`, preventing crashes from built-in activities triggered before Dart-side initialization.
* Updated `pubspec.yaml` to version 2.1.2.
* Documented the bug fix and release in `CHANGELOG.md`.